### PR TITLE
fix USB reset

### DIFF
--- a/u-boot/cpu/mips/ar7240/qca_usb.c
+++ b/u-boot/cpu/mips/ar7240/qca_usb.c
@@ -31,8 +31,8 @@ void usb_init(void)
 	udelay(1000);
 
 	/* Take out USB PHY/HOST/PLL out of reset */
-	qca_soc_reg_read_set(QCA_RST_RESET_REG,
-			     QCA_RST_RESET_USB_PHY_SUSPEND_ORIDE_MASK);
+	qca_soc_reg_read_clear(QCA_RST_RESET_REG,
+			       QCA_RST_RESET_USB_PHY_SUSPEND_ORIDE_MASK);
 	udelay(1000);
 
 	qca_soc_reg_read_clear(QCA_RST_RESET_REG,


### PR DESCRIPTION
Set USB PHY to suspend state during reset/init. Fix for bugtracker
issue: https://bugs.openwrt.org/index.php?do=details&task_id=1835
TP-Link firmware also boots fine with this change.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>