### PR TITLE
increase flash clock limit

### DIFF
--- a/u-boot/include/soc/qca95xx_pll_init.h
+++ b/u-boot/include/soc/qca95xx_pll_init.h
@@ -1537,7 +1537,7 @@
 
 /* Maximum clock for SPI NOR FLASH */
 #ifndef CONFIG_QCA_SPI_NOR_FLASH_MAX_CLK_MHZ
-	#define CONFIG_QCA_SPI_NOR_FLASH_MAX_CLK_MHZ	30
+	#define CONFIG_QCA_SPI_NOR_FLASH_MAX_CLK_MHZ	50
 #endif
 
 /* SPI_CONTROL_ADDR register value */


### PR DESCRIPTION
W25Q128FV can operate at 50MHz with corresponding AHB clock